### PR TITLE
Removing blog from top nav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,10 +26,6 @@ topbar:
     title : 'Resources'
 
   -
-    url: '/blog/'
-    title : 'Blog'
-
-  -
     url : '/press/'
     title : 'Press'
 


### PR DESCRIPTION
Because the blog is not active and it's a misleading top nav link for the latest news. Better to direct visitors to the [Press and Announcements](http://freelawfounders.org/press/) page.
